### PR TITLE
New API support

### DIFF
--- a/src/Commands/HTTPS/ChallengeCommand.php
+++ b/src/Commands/HTTPS/ChallengeCommand.php
@@ -101,7 +101,7 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
         // command is the full dns txt record.
         if ($options['format'] == 'list') {
           $this->log()->notice("Create a DNS txt record containing:\n$txt_record\n");
-          $this->log()->notice('After this is complete, run {command}', ['command' => "terminus acme-dns-verify $site_env $domain"]);
+          $this->log()->notice('After this is complete, run {command}', ['command' => "terminus acme-txt-verify $site_env $domain"]);
         } else {
           return new RowsOfFields([$txt_record => $txt_record_components]);
         }

--- a/src/Commands/HTTPS/ChallengeCommand.php
+++ b/src/Commands/HTTPS/ChallengeCommand.php
@@ -78,7 +78,7 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
      *     text-data: Text Data
      * @return RowsOfFields
      *
-     * @usage <site>.<env> Displays domains associated with <site>'s <env> environment.
+     * @usage <site>.<env> <domain> Obtains an ACME dns-01 challenge you can serve during migration to Pantheon
      */
     public function getChallengeDNStxt($site_env, $domain, $options = ['format' => 'list'])
     {

--- a/src/Commands/HTTPS/ChallengeCommand.php
+++ b/src/Commands/HTTPS/ChallengeCommand.php
@@ -5,6 +5,7 @@ namespace Pantheon\Terminus\Commands\HTTPS;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Util\GetACMEStatus;
@@ -18,8 +19,8 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Writes a challenge file to the current directory (or the specified
-     * location) and prints instructions on how to serve it.
+     * Writes a challenge file to the current directory and prints instructions
+     * on how to serve it.
      *
      * @authorize
      *
@@ -29,7 +30,7 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_env Site & environment in the format `site-name.env`
      * @param string $domain The domain to produce a challenge for.
      *
-     * @usage <site>.<env> Displays domains associated with <site>'s <env> environment.
+     * @usage <site>.<env> <domain> Creates an ACME http-01 challenge file you can serve during migration to Pantheon
      */
     public function writeChallengeFile($site_env, $domain)
     {
@@ -40,17 +41,21 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
 
         // Sanity check: this should never happen, as getACMEStatus should throw
         // in any instance where there is no verification file data.
-        if (empty($data->verification_file_name) || empty($data->verification_file_link)) {
+        if (empty($data->{'http-01'})) {
             throw new TerminusException('No challenge file information available for domain {domain}.', compact('status', 'domain'));
         }
+        $data = $data->{'http-01'};
+        $filename = $data->token;
+        $contents = $data->verification_value;
 
-        $filename = $data->verification_file_name;
-        $contents = file_get_contents($data->verification_file_link);
-
-        file_put_contents($filename, $contents);
-        $this->log()->notice('Wrote ACME challenge to file {filename}', compact('filename'));
-        $this->log()->notice('Please copy this file to your web server so that it will be served from the URL');
-        $this->log()->notice('{url}', ['url' => "http://$domain/.well-known/acme-challenge/$filename"]);
+        if (file_put_contents($filename, $contents)) {
+          $this->log()->notice('Wrote ACME challenge to file {filename}', compact('filename'));
+          $this->log()->notice('Please copy this file to your web server so that it will be served from the URL');
+          $this->log()->notice('http://{domain}{path}', ['domain' => $domain, 'path' => $data->verification_key]);
+          $this->log()->notice('After this is complete, run terminus acme-file-verify.');
+        } else {
+          throw new TerminusException('Failed writing to {filename}', compact('filename'));
+        }
     }
 
     /**
@@ -84,17 +89,18 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
 
         // Sanity check: this should never happen, as getACMEStatus should throw
         // in any instance where there is no verification dns txt record.
-        if (empty($data->verification_dns_txt)) {
+        if (empty($data->{'dns-01'})) {
             throw new TerminusException('No DNS txt record challenge information available for domain {domain}.', compact('status', 'domain'));
         }
+        $data = $data->{'dns-01'};
 
         $txt_record_components = [
             'domain' => $domain,
-            'record-name' => "_acme-challenge.$domain.",
+            'record-name' => $data->verification_key,
             'ttl' => '300',
             'class' => 'IN',
             'record-type' => 'TXT',
-            'text-data' => $data->verification_dns_txt,
+            'text-data' => $data->verification_value,
         ];
 
         $dns_txt_record_tmpl = 'record-name ttl class record-type "text-data"';
@@ -117,33 +123,36 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
     {
         list(, $env) = $this->getSiteEnv($site_env);
 
-        $domains = $env->getDomains()->fetchWithRecommendations();
-        if (!$domains->has($domain)) {
-            $command = "terminus domain:add $site_env $domain";
-            $this->log()->notice('The domain {domain} has not been added to this site and environment. Use the command {command} to add it.', compact('domain', 'command'));
-            throw new TerminusException('Cannot create challenge for missing domain.');
-        }
-        $domainToVerify = $domains->get($domain);
-
+        $domains = $env->getDomains();
         //$data = $domains->getACMEStatus($domainToVerify->id);
-        $data = GetACMEStatus::get($domains, $domainToVerify->id);
-        $data = $data->ownership_status;
-        $status = $data->status;
+        try {
+          $data = GetACMEStatus::get($domains, $domain);
+        } catch (TerminusNotFoundException $e) {
+          $command = "terminus domain:add $site_env $domain";
+          $this->log()->notice('The domain {domain} has not been added to this site and environment. Use the command {command} to add it.', compact('domain', 'command'));
+          throw new TerminusException('Cannot create challenge for missing domain.');
+        }
+
+        $ownership = $data->ownership_status;
+        $status = $ownership->status;
 
         if ($status == 'completed') {
             $this->log()->notice('Domain verification for {domain} has been completed.', compact('domain'));
-            return [$data, false];
+            return [null, false];
         }
 
         if ($status == 'not_required') {
             $this->log()->notice('Domain verification for {domain} is not necessary; https has not been configured for this domain in its current location.', compact('domain'));
-            return [$data, false];
+            return [null, false];
         }
 
         if ($status != 'required') {
             throw new TerminusException('Unimplemented status {status} for domain {domain}.', compact('status', 'domain'));
         }
 
-        return [$data, true];
+        if (empty($data->acme_preauthorization_challenges)) {
+          throw new TerminusException('No challenge information currently available for domain {domain}.', compact('domain'));
+        }
+        return [$data->acme_preauthorization_challenges, true];
     }
 }

--- a/src/Commands/HTTPS/ChallengeCommand.php
+++ b/src/Commands/HTTPS/ChallengeCommand.php
@@ -52,7 +52,7 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
           $this->log()->notice('Wrote ACME challenge to file {filename}', compact('filename'));
           $this->log()->notice('Please copy this file to your web server so that it will be served from the URL');
           $this->log()->notice('http://{domain}{path}', ['domain' => $domain, 'path' => $data->verification_key]);
-          $this->log()->notice('After this is complete, run terminus acme-file-verify.');
+          $this->log()->notice('After this is complete, run {command}', ['command' => "terminus acme-file-verify $site_env $domain"]);
         } else {
           throw new TerminusException('Failed writing to {filename}', compact('filename'));
         }
@@ -82,18 +82,32 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function getChallengeDNStxt($site_env, $domain, $options = ['format' => 'list'])
     {
-        list($data, $acmeStatus) = $this->getACMEStatus($site_env, $domain);
-        if (!$acmeStatus) {
-            return;
-        }
+      list($data, $acmeStatus) = $this->getACMEStatus($site_env, $domain);
+      if (!$acmeStatus) {
+        return;
+      }
 
-        // Sanity check: this should never happen, as getACMEStatus should throw
-        // in any instance where there is no verification dns txt record.
-        if (empty($data->{'dns-01'})) {
-            throw new TerminusException('No DNS txt record challenge information available for domain {domain}.', compact('status', 'domain'));
+      // Sanity check: this should never happen, as getACMEStatus should throw
+      // in any instance where there is no verification dns txt record.
+      if (empty($data->{'dns-01'})) {
+        throw new TerminusException('No DNS txt record challenge information available for domain {domain}.', compact('status', 'domain'));
+      }
+      $data = $data->{'dns-01'};
+      $struct = ChallengeCommand::formatChallengeDNStxt($domain, $data);
+      $txt_record = $struct[0];
+      $txt_record_components = $struct[1];
+      // Provide instructions in a log message when the format is 'list'
+        // n.b. 'list' format prints out each line's key, which for this
+        // command is the full dns txt record.
+        if ($options['format'] == 'list') {
+          $this->log()->notice("Create a DNS txt record containing:\n$txt_record\n");
+          $this->log()->notice('After this is complete, run {command}', ['command' => "terminus acme-dns-verify $site_env $domain"]);
+        } else {
+          return new RowsOfFields([$txt_record => $txt_record_components]);
         }
-        $data = $data->{'dns-01'};
+    }
 
+    public static function formatChallengeDNStxt($domain, $data) {
         $txt_record_components = [
             'domain' => $domain,
             'record-name' => $data->verification_key,
@@ -106,13 +120,7 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
         $dns_txt_record_tmpl = 'record-name ttl class record-type "text-data"';
         $txt_record = str_replace(array_keys($txt_record_components), array_values($txt_record_components), $dns_txt_record_tmpl);
 
-        // Provide instructions in a log message when the format is 'list'
-        // n.b. 'list' format prints out each line's key, which for this
-        // command is the full dns txt record.
-        if ($options['format'] == 'list') {
-            $this->log()->notice('Create a DNS txt record containing:', compact('contents', 'domain'));
-        }
-        return new RowsOfFields([$txt_record => $txt_record_components]);
+        return [$txt_record, $txt_record_components];
     }
 
     /**
@@ -144,6 +152,10 @@ class ChallengeCommand extends TerminusCommand implements SiteAwareInterface
         if ($status == 'not_required') {
             $this->log()->notice('Domain verification for {domain} is not necessary; https has not been configured for this domain in its current location.', compact('domain'));
             return [null, false];
+        }
+
+        if ($status == 'unavailable' && !empty($ownership->message)) {
+          throw new TerminusException($ownership->message);
         }
 
         if ($status != 'required') {

--- a/src/Commands/HTTPS/ChallengeVerifyCommand.php
+++ b/src/Commands/HTTPS/ChallengeVerifyCommand.php
@@ -34,12 +34,30 @@ class ChallengeVerifyCommand extends TerminusCommand implements SiteAwareInterfa
     $this->verifyChallenge($site_env, $domain, 'http-01');
   }
 
+  /**
+   * Triggers acceptance of the ACME dns-01 challenge returned by alpha:https:challenge:dns
+   * and prints whether ownership of the domain was successfully proven.
+   *
+   * @authorize
+   *
+   * @command alpha:https:challenge:dns-txt:verify
+   * @aliases acme-dns-verify
+   *
+   * @param string $site_env Site & environment in the format `site-name.env`
+   * @param string $domain The domain name to verify.
+   * @usage <site>.<env> <domain> Verifies your ownership of <domain> by querying for a DNS TXT record.
+   */
+  public function verifyDnsChallenge($site_env, $domain)
+  {
+    $this->verifyChallenge($site_env, $domain, 'dns-01');
+  }
+
   protected function verifyChallenge($site_env, $domain, $challenge_type) {
     list(, $env) = $this->getSiteEnv($site_env);
 
     $domains = $env->getDomains();
 
-    // Check if it's already been verified.
+    // Check if it's already been verified, and note current challenges.
     $data = GetACMEStatus::get($domains, $domain);
     // This happens if the domain status object could not be built by the deadline.
     // In this case, launch ownership verification, but we may not be able to poll.
@@ -49,6 +67,11 @@ class ChallengeVerifyCommand extends TerminusCommand implements SiteAwareInterfa
       $preprovision_result = $data->{'ownership_status'};
       $preprovision_result = $preprovision_result->{'preprovision_result'};
       $status = $preprovision_result->status;
+    }
+
+    $current_challenge = '';
+    if (!empty($data->acme_preauthorization_challenges)) {
+      $current_challenge = $data->acme_preauthorization_challenges->$challenge_type->verification_value;
     }
 
     switch ($status) {
@@ -96,7 +119,8 @@ class ChallengeVerifyCommand extends TerminusCommand implements SiteAwareInterfa
       $status = $preprovision_result->status;
       switch ($status) {
         case 'failed':
-          $this->handleVerificationFailed();
+          $this->handleVerificationFailed($site_env, $domain, $current_challenge, $data, $challenge_type);
+          return;
         case 'success':
           $this->log()->notice('Ownership verification is complete!');
           $this->log()->notice('Your HTTPS certificate will be deployed to Pantheon\'s Global CDN shortly.');
@@ -104,13 +128,75 @@ class ChallengeVerifyCommand extends TerminusCommand implements SiteAwareInterfa
       }
     }
 
-    $this->handleVerificationFailed();
+    $this->handleVerificationFailed($site_env, $domain, $current_challenge, $data, $challenge_type);
   }
 
-  protected function handleVerificationFailed() {
-    $this->log()->notice('Double-check that your challenge is being served correctly.');
-    $this->log()->notice('See {link} for assistance', ['link' => 'https://pantheon.io/docs/guides/launch/domains']);
-    $this->log()->notice('or contact Pantheon Support. You may try again up to 5 times per hour.');
+  protected function handleVerificationFailed($site_env, $domain, $current_challenge, $data, $challenge_type) {
+    // Display rich error information if we have any.
+    $preprovision_result = $data->{'ownership_status'};
+    $preprovision_result = $preprovision_result->{'preprovision_result'};
+    $pantheon_docs = 'https://pantheon.io/docs/guides/launch/domains';
+    $support_ref = '';
+    if (!empty($preprovision_result->last_preprovision_problem)) {
+      $problem = $preprovision_result->last_preprovision_problem;
+      if (!empty($problem->PantheonDocsLink)) {
+        $pantheon_docs = $problem->PantheonDocsLink;
+      }
+      if (!empty($problem->SupportReference)) {
+        $support_ref = " with reference \"" . $problem->SupportReference . '"';
+      }
+      if (!empty($problem->PantheonTitle)) {
+        $this->log()->notice($problem->PantheonTitle);
+      }
+      if (!empty($problem->PantheonDetail)) {
+        $this->log()->notice($problem->PantheonDetail);
+      }
+      if (!empty($problem->PantheonActionItem)) {
+        $this->log()->notice($problem->PantheonActionItem);
+      }
+
+      if (!empty($problem->Detail) || !empty($problem->ProblemType)) {
+        $this->log()->notice('');
+        $detail = '';
+        if (!empty($problem->ProblemType)) {
+          $detail = $detail . "\n" . $problem->ProblemType;
+        }
+        if (!empty($problem->Detail)) {
+          $detail = $detail . "\n" . $problem->Detail;
+        }
+        $this->log()->notice("Raw verification result:$detail");
+      }
+    } else {
+      $this->log()->notice('Double-check that your challenge is being served correctly.');
+    }
+
+    $this->log()->notice('See {link} for assistance', ['link' => $pantheon_docs]);
+    $this->log()->notice("or contact Pantheon Support$support_ref.");
+
+    // Warn if ownership verification has become unavailable.
+    // (Typically user has attempted more times than LE allows per hour)
+    if ($data->ownership_status->status == 'unavailable' && !empty($data->ownership_status->message)) {
+      $this->log()->warning($data->ownership_status->message);
+    }
+
+    // Warn if the challenge had to be changed.
+    if (!empty($data->acme_preauthorization_challenges)) {
+      $new_challenge = $data->acme_preauthorization_challenges->$challenge_type->verification_value;
+      if ($new_challenge != $current_challenge) {
+        $this->log()->warning('The old challenge cannot be tried again.');
+        if ($challenge_type == 'dns-01') {
+          $struct = ChallengeCommand::formatChallengeDNStxt($domain, $data->acme_preauthorization_challenges->{'dns-01'});
+          $txt_record = $struct[0];
+          $this->log()->warning("Please update your DNS to serve the new challenge below:\n$txt_record");
+        }
+        if ($challenge_type == 'http-01') {
+          $this->log()->warning('Please run {command} again to obtain a new challenge file.',
+            ['command' => "terminus alpha:https:challenge:file $site_env $domain"]
+          );
+        }
+      }
+    }
+
     throw new TerminusException('Ownership verification was not successful.');
   }
 }

--- a/src/Commands/HTTPS/ChallengeVerifyCommand.php
+++ b/src/Commands/HTTPS/ChallengeVerifyCommand.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\HTTPS;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Util\GetACMEStatus;
+
+/**
+ * Class ChallengeVerifyCommand
+ * @package Pantheon\Terminus\Commands\HTTPS
+ */
+class ChallengeVerifyCommand extends TerminusCommand implements SiteAwareInterface {
+  use SiteAwareTrait;
+
+  /**
+   * Triggers acceptance of the ACME http-01 challenge returned by alpha:https:challenge:file
+   * and prints whether ownership of the domain was successfully proven.
+   *
+   * @authorize
+   *
+   * @command alpha:https:challenge:file:verify
+   * @aliases acme-file-verify
+   *
+   * @param string $site_env Site & environment in the format `site-name.env`
+   * @param string $domain The domain name to verify.
+   * @usage <site>.<env> <domain> Verifies your ownership of <domain> by attempting to fetch a file over http.
+   */
+  public function verifyHttpChallenge($site_env, $domain)
+  {
+    $this->verifyChallenge($site_env, $domain, 'http-01');
+  }
+
+  protected function verifyChallenge($site_env, $domain, $challenge_type) {
+    list(, $env) = $this->getSiteEnv($site_env);
+
+    $domains = $env->getDomains();
+
+    // Check if it's already been verified.
+    $data = GetACMEStatus::get($domains, $domain);
+    // This happens if the domain status object could not be built by the deadline.
+    // In this case, launch ownership verification, but we may not be able to poll.
+    if (empty($data->{'ownership_status'})) {
+      $status = "failed";
+    } else {
+      $preprovision_result = $data->{'ownership_status'};
+      $preprovision_result = $preprovision_result->{'preprovision_result'};
+      $status = $preprovision_result->status;
+    }
+
+    switch ($status) {
+      case "success":
+        $this->log()->notice("Ownership verification for {domain} is complete!", ['domain' => $domain]);
+        return;
+      case "failed":
+        try {
+          GetACMEStatus::startVerification($domains, $domain, $challenge_type);
+        } catch (TerminusNotFoundException $e) {
+          $command = "terminus domain:add $site_env $domain";
+          $this->log()->notice('The domain {domain} has not been added to this site and environment. Use the command {command} to add it.', compact('domain', 'command'));
+          throw new TerminusException('Cannot verify challenge for missing domain.');
+        }
+
+        $this->log()->notice('The challenge for {domain} is being verified...', compact('domain'));
+        break;
+      case "in_progress":
+        // The third possibility, we'll just start polling in this case.
+    }
+
+    $pollFailures = 0;
+    for ($polls = 0; $polls < 15; $polls++) {
+      sleep(10);
+      try {
+        $data = GetACMEStatus::get($domains, $domain);
+      } catch (\Exception $e) {
+        $pollFailures++;
+        if ($pollFailures > 3) {
+          throw $e;
+        }
+        continue;
+      }
+
+      if (empty($data->{'ownership_status'})) {
+        $pollFailures++;
+        if ($pollFailures > 10) {
+          throw new TerminusException("Due to an error, we are temporarily unable to verify domain ownership.");
+        }
+        continue;
+      }
+
+      $preprovision_result = $data->{'ownership_status'};
+      $preprovision_result = $preprovision_result->{'preprovision_result'};
+      $status = $preprovision_result->status;
+      switch ($status) {
+        case 'failed':
+          $this->handleVerificationFailed();
+        case 'success':
+          $this->log()->notice('Ownership verification is complete!');
+          $this->log()->notice('Your HTTPS certificate will be deployed to Pantheon\'s Global CDN shortly.');
+          return;
+      }
+    }
+
+    $this->handleVerificationFailed();
+  }
+
+  protected function handleVerificationFailed() {
+    $this->log()->notice('Double-check that your challenge is being served correctly.');
+    $this->log()->notice('See {link} for assistance', ['link' => 'https://pantheon.io/docs/guides/launch/domains']);
+    $this->log()->notice('or contact Pantheon Support. You may try again up to 5 times per hour.');
+    throw new TerminusException('Ownership verification was not successful.');
+  }
+}

--- a/src/Commands/HTTPS/ChallengeVerifyCommand.php
+++ b/src/Commands/HTTPS/ChallengeVerifyCommand.php
@@ -41,7 +41,7 @@ class ChallengeVerifyCommand extends TerminusCommand implements SiteAwareInterfa
    * @authorize
    *
    * @command alpha:https:challenge:dns-txt:verify
-   * @aliases acme-dns-verify
+   * @aliases acme-txt-verify
    *
    * @param string $site_env Site & environment in the format `site-name.env`
    * @param string $domain The domain name to verify.

--- a/src/Util/GetACMEStatus.php
+++ b/src/Util/GetACMEStatus.php
@@ -1,6 +1,10 @@
 <?php
 namespace Pantheon\Terminus\Util;
 
+use GuzzleHttp\Exception\ClientException;
+use Pantheon\Terminus\Collections\Domains;
+use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
+
 /**
  * Class GetACMEStatus
  *
@@ -17,10 +21,57 @@ namespace Pantheon\Terminus\Util;
  */
 class GetACMEStatus
 {
+  /**
+   * @param Domains $domains
+   * @param string $domain
+   * @throws TerminusNotFoundException
+   */
     public static function get($domains, $domain)
     {
         $url = $domains->getUrl() . '/' . rawurlencode($domain);
-        $data = $domains->request()->request($url, ['method' => 'get',]);
+        try {
+          $data = $domains->request()->request($url, ['method' => 'get', 'query' => ['acme_version' => 2]]);
+        } catch (ClientException $e) {
+          // Detect if this is just because the input domain is not on the site-env
+          if ($e->getCode() == 404) {
+            throw new TerminusNotFoundException(
+              "The domain {domain} has not been added to the site and environment.",
+              ['domain' => $domain],
+              $e->getCode()
+            );
+          }
+          throw $e;
+        }
+
         return $data['data'];
+    }
+
+  /**
+   * Sends a request to trigger backend async verification of the challenge.
+   *
+   * @param Domains $domains
+   * @param string $domain
+   * @param string $challengeType
+   * @throws TerminusNotFoundException
+   */
+    public static function startVerification($domains, $domain, $challengeType) {
+      $url = $domains->getUrl() . '/' . rawurlencode($domain) . '/' . 'verify-ownership';
+      $body = [
+        'challenge_type' => $challengeType,
+        'client' => 'terminus-plugin', // Only in case we want statistics
+      ];
+      try {
+        $domains->request()->request($url, ['method' => 'POST', 'form_params' => $body]);
+      } catch (ClientException $e) {
+        // Detect if this is just because the input domain is not on the site-env
+        if ($e->getCode() == 404) {
+          throw new TerminusNotFoundException(
+            "The domain {domain} has not been added to the site and environment.",
+            ['domain' => $domain],
+            $e->getCode()
+          );
+        }
+        throw $e;
+      }
     }
 }


### PR DESCRIPTION
This PR updates the ACME plugin to support various backend changes at Pantheon that were necessary in our move to ACMEv2.

The most important difference is the addition of two new commands, `alpha:https:challenge:file:verify` and `alpha:https:challenge:dns-txt:verify` that must be run after deployment of the respective challenge type. This should be a UX improvement that brings us more in line with other ACME clients like certbot -- rather than deploying the challenge and waiting in hopes you did it correctly, you can now inform Pantheon immediately when challenge verification should proceed, and receive feedback from these commands about success or failure.

It also

- handles the new situation where attempting a verification that is unsuccessful can necessitate changing the challenge being served
- handles the situation where the user has attempted too many verifications unsuccessfully and must now wait before trying again. This is pending backend detection of this condition, and assumes it will be reported through `ownership_status.message` when `ownership_status.status` is "unavailable"
- optimistically adds support for display of enhanced verification error messages (specifics of the problem, suggested remediation, contextual docs link, etc) in the feedback provided by the `:verify` commands. The backend does not yet support these enhanced errors, but development is far enough along to know the schema.