### PR TITLE
Increase the Terminus compatibility version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "terminus": {
-            "compatible-version": "^1|^2"
+            "compatible-version": "^1|^2|^3"
         }
     }
 }


### PR DESCRIPTION
This plugin works with terminus 3. it just needs its compatibility increased to allow terminus to install it. In the meantime for people wanting to use it in T3, follow these steps:

1. Download/clone the plugin
2. cd to plugin
3. run `terminus self:plugin:install .` (note the trailing dot)